### PR TITLE
Allow creation of parent directories.

### DIFF
--- a/condawrapper.sh
+++ b/condawrapper.sh
@@ -240,7 +240,7 @@ mkcondaenv () {
   fi
   # Create a condawrapper config for the environment:
   env_dir="$CONDAWRAPPER_HOME/$env_name"
-  if ! mkdir $env_dir; then
+  if ! mkdir -p $env_dir; then
     __err "error: failed to create condawrapper configuration directory: $env_dir"
     return 1
   fi


### PR DESCRIPTION
Create the environment configuration directory even if the main configuration directory does not exist yet, as might happen the first time condawrapper is used to create an environment.
