### PR TITLE
Handle errors and notifications when creating a new environment.

### DIFF
--- a/condawrapper.sh
+++ b/condawrapper.sh
@@ -249,6 +249,7 @@ mkcondaenv () {
     __err "error: failed to activate the new environment '${env_name}'"
     return 2
   fi
+  echo "Activated environment '${env_name}'"
   return 0
 }
 

--- a/condawrapper.sh
+++ b/condawrapper.sh
@@ -240,7 +240,7 @@ mkcondaenv () {
   fi
   # Create a condawrapper config for the environment:
   env_dir="$CONDAWRAPPER_HOME/$env_name"
-  if ! mkdir $env_dir; then
+  if ! mkdir -p $env_dir; then
     __err "error: failed to create condawrapper configuration directory: $env_dir"
     return 1
   fi


### PR DESCRIPTION
Protects against errors when creating a configuration directory, and issue a notification that a newly created environment (using `mkcondaenv`) has been activated, handy if you don't change shell prompt when switching environments.
